### PR TITLE
Add support for prompts, notifications and context.Context

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/time/rate"
 
@@ -37,21 +39,51 @@ func main() {
 		},
 	}
 
-	s := mcp.NewServer(serverInfo, tools)
+	prompts := []mcp.PromptDefinition{
+		{
+			Metadata: mcp.Prompt{
+				Name:        "example",
+				Description: ptr("An example prompt template"),
+				Arguments: []mcp.PromptArgument{
+					{
+						Name:        "text",
+						Description: ptr("Text to process"),
+						Required:    ptr(true),
+					},
+				},
+			},
+			Process:   processPrompt,
+			RateLimit: rate.NewLimiter(rate.Every(time.Second), 5),
+		},
+	}
+
+	s := mcp.NewServer(serverInfo, tools, prompts)
 	s.Serve()
 }
 
-func computeSHA256(params mcp.CallToolRequestParams) (mcp.CallToolResult, error) {
+func ptr[T any](t T) *T {
+	return &t
+}
+
+// Update the computeSHA256 function to send a single notification
+func computeSHA256(ctx context.Context, n mcp.Notifier, params mcp.CallToolRequestParams) (mcp.CallToolResult, error) {
 	txt := params.Arguments["text"].(string)
 
 	if len(txt) == 0 {
 		return mcp.CallToolResult{}, errors.New("failed to compute checksum: text cannot be empty")
 	}
 
+	err := n.Notify(ctx, "test/notification", map[string]any{
+		"message": "Processing text",
+	})
+	if err != nil {
+		fmt.Printf("Failed to send notification: %v\n", err)
+	}
+
 	h := sha256.New()
 	h.Write([]byte(txt))
-
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
+
 	var noError bool
 	return mcp.CallToolResult{
 		Content: []any{
@@ -61,5 +93,30 @@ func computeSHA256(params mcp.CallToolRequestParams) (mcp.CallToolResult, error)
 			},
 		},
 		IsError: &noError,
+	}, nil
+}
+
+func processPrompt(ctx context.Context, n mcp.Notifier, params mcp.GetPromptRequestParams) (mcp.GetPromptResult, error) {
+	if params.Arguments["text"] == "" {
+		return mcp.GetPromptResult{}, errors.New("input text cannot be empty")
+	}
+
+	err := n.Notify(ctx, "test/notification", map[string]any{
+		"message": "Processing text",
+	})
+	if err != nil {
+		fmt.Printf("Failed to send notification: %v\n", err)
+	}
+
+	return mcp.GetPromptResult{
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleAssistant,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: "Processed: " + params.Arguments["text"],
+				},
+			},
+		},
 	}, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Server", func() {
 
 	It("responds to an initialization request", func() {
 		stdin.WriteString(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true},"sampling":{}},"clientInfo":{"name":"ExampleClient","version":"1.0.0"}}}`)
-		Eventually(session.Out.Contents).Should(MatchJSON(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"ExampleServer","version":"1.0.0"}}}`))
+		Eventually(session.Out.Contents).Should(MatchJSON(`{"id":1,"result":{"capabilities":{"prompts":{"listChanged":false},"tools":{"listChanged":false}},"protocolVersion":"2024-11-05","serverInfo":{"name":"ExampleServer","version":"1.0.0"}},"jsonrpc":"2.0"}`))
 	})
 
 	It("responds to pings", func() {
@@ -77,7 +77,7 @@ var _ = Describe("Server", func() {
 	Context("when the client protocol version is newer", func() {
 		It("responds with the latest version supported by the server", func() {
 			stdin.WriteString(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"3000-01-01","capabilities":{"roots":{"listChanged":true},"sampling":{}},"clientInfo":{"name":"ExampleClient","version":"1.0.0"}}}`)
-			Eventually(session.Out.Contents).Should(MatchJSON(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"ExampleServer","version":"1.0.0"}}}`))
+			Eventually(session.Out.Contents).Should(MatchJSON(`{"id":1,"result":{"capabilities":{"prompts":{"listChanged":false},"tools":{"listChanged":false}},"protocolVersion":"2024-11-05","serverInfo":{"name":"ExampleServer","version":"1.0.0"}},"jsonrpc":"2.0"}`))
 		})
 	})
 
@@ -107,7 +107,11 @@ var _ = Describe("Server", func() {
 			It("invokes the tool", func() {
 				stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"sha256sum","arguments":{"text":"the rain in spain falls mainly on the plains"}}}`)
 				Eventually(session.Out).Should(gbytes.Say("\n"))
-				Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"b65aacbdd951ff4cd8acef585d482ca4baef81fa0e32132b842fddca3b5590e9"}],"isError":false}}`))
+
+				responses := allResponses(session.Out.Contents())
+				Expect(responses).To(HaveLen(4)) // First two are initialization, last two are the tool response
+				Expect(responses[len(responses)-2]).To(MatchJSON(`{"jsonrpc":"2.0","method":"test/notification","params":{"message":"Processing text"}}`))
+				Expect(responses[len(responses)-1]).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"b65aacbdd951ff4cd8acef585d482ca4baef81fa0e32132b842fddca3b5590e9"}],"isError":false}}`))
 			})
 		})
 		Context("when the client calls a tool without providing the required arguments", func() {
@@ -141,12 +145,97 @@ var _ = Describe("Server", func() {
 			})
 		})
 	})
+
+	Describe("prompts", func() {
+		BeforeEach(func() {
+			stdin.WriteString(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"roots":{"listChanged":true},"sampling":{}},"clientInfo":{"name":"ExampleClient","version":"1.0.0"}}}`)
+			Eventually(session.Out).Should(gbytes.Say("ExampleServer"))
+			stdin.WriteString(`{"jsonrpc":"2.0","method":"initialized"}`)
+			Eventually(session.Out).Should(gbytes.Say("\n"))
+		})
+
+		Context("when the client requests the list of prompts", func() {
+			It("responds", func() {
+				stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/list"}`)
+				Eventually(session.Out).Should(gbytes.Say("prompts"))
+				Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"prompts":[{"name":"example","description":"An example prompt template","arguments":[{"name":"text","description":"Text to process","required":true}]}]}}`))
+			})
+		})
+
+		Context("when the client requests the list of prompts with an invalid cursor", func() {
+			It("responds with a protocol error", func() {
+				stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/list","params":{"cursor":"invalid-cursor"}}`)
+				Eventually(session.Out).Should(gbytes.Say("\n"))
+				Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":2}`))
+			})
+		})
+
+		Context("when the client gets a prompt", func() {
+			It("processes the prompt with the provided arguments", func() {
+				stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"example","arguments":{"text":"test input"}}}`)
+				Eventually(session.Out).Should(gbytes.Say("\n"))
+
+				responses := allResponses(session.Out.Contents())
+				Expect(responses).To(HaveLen(4)) // First two are initialization, last two are the prompt response
+				Expect(responses[len(responses)-2]).To(MatchJSON(`{"jsonrpc":"2.0","method":"test/notification","params":{"message":"Processing text"}}`))
+				Expect(responses[len(responses)-1]).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"messages":[{"role":"assistant","content":{"type":"text","text":"Processed: test input"}}]}}`))
+			})
+
+			// Missing arguments error
+			Context("when required arguments are missing", func() {
+				It("responds with an error", func() {
+					stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"example","arguments":{}}}`)
+					Eventually(session.Out).Should(gbytes.Say("\n"))
+					Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Missing required argument: text"},"id":2}`))
+				})
+			})
+
+			// Unknown prompt error
+			Context("when the prompt doesn't exist", func() {
+				It("responds with an error", func() {
+					stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"nonexistent","arguments":{}}}`)
+					Eventually(session.Out).Should(gbytes.Say("\n"))
+					Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Unknown prompt: nonexistent"},"id":2}`))
+				})
+			})
+
+			// Prompt processing error
+			Context("when the prompt processing fails", func() {
+				It("responds with a prompt error", func() {
+					stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"example","arguments":{"text":""}}}`)
+					Eventually(session.Out).Should(gbytes.Say("\n"))
+					Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"messages":[{"role":"assistant","content":{"type":"text","text":"input text cannot be empty"}}]}}`))
+				})
+			})
+
+			// Rate limit error
+			Context("when the prompt is called numerous times in a short period", func() {
+				It("triggers the rate limit error", func() {
+					for i := 0; i < 10; i++ {
+						stdin.WriteString(`{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"example","arguments":{"text":"test"}}}`)
+						Eventually(session.Out).Should(gbytes.Say("\n"))
+					}
+					Expect(lastResponse(session.Out.Contents())).To(MatchJSON(`{"jsonrpc":"2.0","id":2,"result":{"messages":[{"role":"assistant","content":{"type":"text","text":"rate limit exceeded"}}]}}`))
+				})
+			})
+		})
+	})
 })
 
 func lastResponse(responses []byte) []byte {
 	newline := []byte("\n")
 	rs := bytes.Split(bytes.TrimSuffix(responses, newline), newline)
 	return rs[len(rs)-1]
+}
+
+func allResponses(responses []byte) [][]byte {
+	var outputs [][]byte
+	for _, line := range bytes.Split(bytes.TrimSuffix(responses, []byte("\n")), []byte("\n")) {
+		if len(line) > 0 {
+			outputs = append(outputs, line)
+		}
+	}
+	return outputs
 }
 
 type blockingReader struct {


### PR DESCRIPTION
This change introduces three enhancements to the MCP server implementation:

1. Prompts Support
- Adds new PromptDefinition type for defining prompt templates
- Implements prompts/list and prompts/get RPC methods
- Adds rate limiting support for prompt processing
- Adds validation for required prompt arguments

2. Notifications System
- Adds Notifier interface for sending MCP notifications
- Implements connNotifier to handle JSON-RPC notifications
- Updates tool and prompt handlers to support custom notification sending

3. Context Support
- Adds context.Context to tool and prompt execution functions
- Enables proper cancellation and timeout handling
- Allows for better request lifecycle management

Example usage shows how to:
- Define and process prompts with arguments
- Send notifications during tool/prompt execution
- Use rate limiting for both tools and prompts
- Handle various error cases and validation

Updates test suite to cover new functionality including:
- Prompt listing and processing
- Notification sending
- Rate limiting behavior
- Error handling for missing/invalid arguments

Breaking Changes:
- Tool execution function signature changes to include context and notifier